### PR TITLE
Ignored vendor/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ _testmain.go
 *.test
 *.prof
 
+vendor/


### PR DESCRIPTION
[go 1.6](https://golang.org/doc/go1.6) で正式にvendoring対応が入って、`vendor/` 配下のディレクトリを読んでくれるようになってます。

`vendor/` 配下は [dep](https://github.com/golang/dep) や [glide](https://github.com/Masterminds/glide) などのパッケージ管理ツールでインストールするためコミット不要です
